### PR TITLE
TD-256: Promote select pooler events into beats

### DIFF
--- a/include/pulse.hrl
+++ b/include/pulse.hrl
@@ -278,6 +278,23 @@
     duration :: non_neg_integer()
 }).
 
+%% Riak connection pool events
+
+-record(mg_core_riak_connection_pool_state_reached, {
+    name :: mg_core_storage:name(),
+    state :: no_free_connections | queue_limit_reached
+}).
+
+-record(mg_core_riak_connection_pool_connection_killed, {
+    name :: mg_core_storage:name(),
+    state :: free | in_use
+}).
+
+-record(mg_core_riak_connection_pool_error, {
+    name :: mg_core_storage:name(),
+    reason :: connect_timeout
+}).
+
 %% Workers management
 
 -record(mg_core_worker_call_attempt, {

--- a/src/mg_core_pulse.erl
+++ b/src/mg_core_pulse.erl
@@ -80,7 +80,10 @@
     | #mg_core_riak_client_search_start{}
     | #mg_core_riak_client_search_finish{}
     | #mg_core_riak_client_delete_start{}
-    | #mg_core_riak_client_delete_finish{}.
+    % Riak client call handling
+    | #mg_core_riak_connection_pool_state_reached{}
+    | #mg_core_riak_connection_pool_connection_killed{}
+    | #mg_core_riak_connection_pool_error{}.
 
 -type handler() :: mg_core_utils:mod_opts() | undefined.
 

--- a/test/mg_core_storages_SUITE.erl
+++ b/test/mg_core_storages_SUITE.erl
@@ -368,9 +368,7 @@ storage_options(riak, Namespace) ->
             idle_timeout => 1000,
             cull_interval => 1000,
             auto_grow_threshold => 5,
-            queue_max => 100,
-            metrics_mod => pooler_no_metrics,
-            metrics_api => folsom
+            queue_max => 100
         }
     }};
 storage_options(memory, _) ->

--- a/test/mg_core_storages_SUITE.erl
+++ b/test/mg_core_storages_SUITE.erl
@@ -450,9 +450,9 @@ riak_pool_misbehaving_connection_test(_C) ->
             case RequestID of
                 N when (N rem WorkersCount) == (N div WorkersCount) ->
                     % Ensure that request fails occasionally...
-                    ?assertExit(
-                        _,
-                        mg_core_storage:get(Storage, invalid_key)
+                    ?assertThrow(
+                        {logic, _},
+                        mg_core_storage:get(Storage, <<>>)
                     );
                 _ ->
                     % ...And it will not affect any concurrently running requests.

--- a/test/mg_core_storages_SUITE.erl
+++ b/test/mg_core_storages_SUITE.erl
@@ -22,6 +22,7 @@
 %%%
 -module(mg_core_storages_SUITE).
 -include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 %% tests descriptions
 -export([all/0]).
@@ -38,6 +39,9 @@
 -export([key_length_limit_test/1]).
 -export([indexes_test_with_limits/1]).
 -export([stress_test/1]).
+
+-export([riak_pool_stable_test/1]).
+-export([riak_pool_overload_test/1]).
 
 -export([handle_beat/2]).
 
@@ -59,7 +63,12 @@ all() ->
 groups() ->
     [
         {memory, [], tests()},
-        {riak, [], tests()}
+        {riak, [],
+            tests() ++
+                [
+                    riak_pool_stable_test,
+                    riak_pool_overload_test
+                ]}
     ].
 
 -spec tests() -> [test_name()].
@@ -354,28 +363,104 @@ stop_wait(Pid, Reason, Timeout) ->
 
 %%
 
--spec storage_options(atom(), binary()) -> mg_core_storage:options().
-storage_options(riak, Namespace) ->
-    {mg_core_storage_riak, #{
-        name => storage,
-        pulse => ?MODULE,
-        host => "riakdb",
-        port => 8087,
-        bucket => Namespace,
-        pool_options => #{
+-spec riak_pool_stable_test(_C) -> ok.
+riak_pool_stable_test(_C) ->
+    Namespace = <<"riak_pool_stable_test">>,
+    InitialCount = 1,
+    RequestCount = 10,
+    Options = riak_options(Namespace, #{
+        init_count => InitialCount,
+        max_count => RequestCount div 2,
+        idle_timeout => 1000,
+        cull_interval => 1000,
+        queue_max => RequestCount * 2
+    }),
+    Storage = {mg_core_storage_riak, Options},
+    Pid = start_storage(Storage),
+
+    % Run multiple requests concurrently
+    _ = genlib_pmap:map(
+        fun(N) ->
+            base_test(genlib:to_binary(N), Storage)
+        end,
+        lists:seq(1, RequestCount)
+    ),
+
+    % Give pool 3 seconds to get back to initial state
+    ok = timer:sleep(3000),
+
+    {ok, Utilization} = mg_core_storage_riak:pool_utilization(Options),
+    ?assertMatch(
+        #{
+            in_use_count := 0,
+            free_count := InitialCount
+        },
+        maps:from_list(Utilization)
+    ),
+
+    ok = stop_storage(Pid).
+
+-spec riak_pool_overload_test(_C) -> ok.
+riak_pool_overload_test(_C) ->
+    Namespace = <<"riak_pool_overload_test">>,
+    RequestCount = 40,
+    Options = riak_options(
+        Namespace,
+        #{
             init_count => 1,
-            max_count => 10,
+            max_count => 4,
             idle_timeout => 1000,
             cull_interval => 1000,
-            auto_grow_threshold => 5,
-            queue_max => 100
+            queue_max => RequestCount div 4
         }
-    }};
+    ),
+    Storage = {mg_core_storage_riak, Options},
+    Pid = start_storage(Storage),
+
+    ?assertThrow(
+        {transient, {storage_unavailable, no_pool_members}},
+        genlib_pmap:map(
+            fun(N) ->
+                base_test(genlib:to_binary(N), Storage)
+            end,
+            lists:seq(1, RequestCount)
+        )
+    ),
+
+    ok = stop_storage(Pid).
+
+%%
+
+-spec storage_options(atom(), binary()) -> mg_core_storage:options().
+storage_options(riak, Namespace) ->
+    {mg_core_storage_riak,
+        riak_options(
+            Namespace,
+            #{
+                init_count => 1,
+                max_count => 10,
+                idle_timeout => 1000,
+                cull_interval => 1000,
+                auto_grow_threshold => 5,
+                queue_max => 100
+            }
+        )};
 storage_options(memory, _) ->
     {mg_core_storage_memory, #{
         pulse => ?MODULE,
         name => storage
     }}.
+
+-spec riak_options(mg_core:ns(), map()) -> mg_core_storage_riak:options().
+riak_options(Namespace, PoolOptions) ->
+    #{
+        name => storage,
+        pulse => ?MODULE,
+        host => "riakdb",
+        port => 8087,
+        bucket => Namespace,
+        pool_options => PoolOptions
+    }.
 
 -spec start_storage(mg_core_storage:options()) -> pid().
 start_storage(Options) ->

--- a/test/mg_core_storages_SUITE.erl
+++ b/test/mg_core_storages_SUITE.erl
@@ -447,18 +447,19 @@ riak_pool_misbehaving_connection_test(_C) ->
 
     _ = genlib_pmap:map(
         fun(RequestID) ->
+            Key = genlib:to_binary(RequestID),
             case RequestID of
                 N when (N rem WorkersCount) == (N div WorkersCount) ->
                     % Ensure that request fails occasionally...
                     ?assertThrow(
-                        {logic, _},
-                        mg_core_storage:get(Storage, <<>>)
+                        {transient, {storage_unavailable, _}},
+                        mg_core_storage:put(Storage, Key, <<"NOTACONTEXT">>, <<>>, [])
                     );
                 _ ->
                     % ...And it will not affect any concurrently running requests.
                     ?assertEqual(
                         undefined,
-                        mg_core_storage:get(Storage, genlib:to_binary(RequestID))
+                        mg_core_storage:get(Storage, Key)
                     )
             end
         end,


### PR DESCRIPTION
Also avoid base64 encoding step on every pool interaction, use (hopefully less costly) gproc lookup instead.